### PR TITLE
Add support for fields_for

### DIFF
--- a/lib/phlex/rails/form.rb
+++ b/lib/phlex/rails/form.rb
@@ -3,65 +3,17 @@
 module Phlex
 	module Rails
 		class Form < Phlex::HTML
-			def initialize(model)
+			def initialize(model, **opts)
 				@model = model
-			end
-
-			def self.input_field(method_name, type:)
-				define_method method_name do |field, value: @model.attributes[field.to_s], **attributes|
-					input(
-						name: field_name(field),
-						type: type,
-						value: value,
-						**attributes
-					)
-				end
+				@url = opts[:url] || @_view_context.url_for(@model)
+				@method = opts[:method] || @model.persisted? ? :patch : :post
 			end
 
 			def template(&block)
-				form action: @url, method: @method do
-					authenticity_token_field
-					yield_content(&block)
+				render FormWith.new model: @model, action: @url, method: @method do
+					yield
 				end
 			end
-
-			def authenticity_token_field
-				input(
-					name: "authenticity_token",
-					type: "hidden",
-					value: @_view_context.form_authenticity_token
-				)
-			end
-
-			def submit(value)
-				input(
-					name: "commit",
-					type: "submit",
-					value: value
-				)
-			end
-
-			def url
-				@_view_context.url_for(@model)
-			end
-
-			def field_name(*field)
-				@_view_context.field_name(ActiveModel::Naming.param_key(@model.class), *field)
-			end
-
-			input_field :url_field, type: "url"
-			input_field :text_field, type: "text"
-			input_field :date_field, type: "date"
-			input_field :time_field, type: "time"
-			input_field :week_field, type: "week"
-			input_field :month_field, type: "month"
-			input_field :email_field, type: "email"
-			input_field :color_field, type: "color"
-			input_field :hidden_field, type: "hidden"
-			input_field :search_field, type: "search"
-			input_field :password_field, type: "password"
-			input_field :telephone_field, type: "tel"
-			input_field :datetime_local_field, type: "datetime-local"
 		end
 	end
 end

--- a/lib/phlex/rails/form_fields.rb
+++ b/lib/phlex/rails/form_fields.rb
@@ -1,0 +1,68 @@
+module Phlex
+  module Rails
+    class FormFields < Phlex::HTML
+			def initialize(form:, scopes:)
+				@scopes = Array.wrap(scopes).compact
+				@form = form
+			end
+
+			def self.input_field(method_name, type:)
+				define_method method_name do |field, value: @model.attributes[field.to_s], **attributes|
+					input(
+						name: field_name(field),
+						type: type,
+						value: value,
+						**attributes
+					)
+				end
+			end
+
+			def authenticity_token_field
+				input(
+					name: "authenticity_token",
+					type: "hidden",
+					value: @_view_context.form_authenticity_token
+				)
+			end
+
+			def submit(value)
+				input(
+					name: "commit",
+					type: "submit",
+					value: value
+				)
+			end
+
+			def template(&blk)
+				yield
+			end
+
+			def field_name(field_name)
+				fields = [*@scopes, field_name].compact
+				field_string = fields[0].to_s.dup
+				field_string << fields[1..-1].map { |f| "[#{f}]" }.join
+				field_string
+			end
+
+			def fields_for(scope, &blk)
+				render FormFields.new(form: @form, scopes: [*@scopes, *Array.wrap(scope)]) do
+					yield
+				end
+			end
+
+			input_field :url_field, type: "url"
+			input_field :text_field, type: "text"
+			input_field :date_field, type: "date"
+			input_field :time_field, type: "time"
+			input_field :week_field, type: "week"
+			input_field :month_field, type: "month"
+			input_field :email_field, type: "email"
+			input_field :color_field, type: "color"
+			input_field :hidden_field, type: "hidden"
+			input_field :search_field, type: "search"
+			input_field :password_field, type: "password"
+			input_field :telephone_field, type: "tel"
+			input_field :datetime_local_field, type: "datetime-local"
+		end
+	end
+end

--- a/lib/phlex/rails/form_with.rb
+++ b/lib/phlex/rails/form_with.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Phlex
+	module Rails
+		class FormWith < Phlex::HTML
+			def initialize(model: nil, scope: nil, url: nil, method: :post, form_options: {})
+				@model = model
+				@scope = scope || ActiveModel::Naming.param_key(@model.class)
+				@url = url || @_view_context.url_for(@model)
+				@method = method
+				@form_options = form_options
+			end
+
+			def template(&block)
+				form action: @url, method: @method, **@form_options do
+					render FormFields.new(form: self, scopes: @scope) do |form_fields|
+						form_fields.authenticity_token_field
+
+						yield form_fields if block_given?
+					end
+				end
+			end
+		end
+	end
+end


### PR DESCRIPTION
This PR will give added support for `fields_for` to allow for namespaced inputs. This is was accomplished by adding a `FormFields` class which is what is actually handling the rendering of inputs, rather than the form class itself.

When using `fields_for`, the `FormFields` object instantiates a new `FormFields` within itself, adding to the `scopes` array. The `scopes` array is used to build the naming for each field. The current `field_name` method feels a bit clunky but it seems to get the job done. Sample of how a form might look:

```
render Phlex::Rails::Form.new(model: model) do |f| 
  # note that `f` here is the form_field, the form is accessible via `f.form`
  
  f.text_input :name
  f.fields_for :foo do |ff|    

    # here is a new form_field object that was yielded as `ff`
    ff.password_input :plain_password

    # the original form_field object is still accessbile via `f` within the fields_for block
    f.email                              
  end

  f.submit
end
```