### PR TITLE
Fix namespacing for Phlex::Testing::Rails::ViewHelper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
-gem "phlex", github: "joeldrapper/phlex"
+gem "phlex", github: "joeldrapper/phlex", branch: "main"
 gem "sus"
 gem "combustion"
 gem "rubocop"

--- a/lib/phlex/testing/rails/view_helper.rb
+++ b/lib/phlex/testing/rails/view_helper.rb
@@ -5,7 +5,7 @@ require "phlex/testing/view_helper"
 module Phlex::Testing
 	module Rails
 		module ViewHelper
-			include Phlex::Testing::ViewHelper
+			include ::Phlex::Testing::ViewHelper
 
 			def view_context
 				controller.view_context

--- a/test/testing/rails/view_helper.rb
+++ b/test/testing/rails/view_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require "phlex/testing/rails"
+require "phlex/testing/rails/view_helper"
+require "action_view/test_case"
 
 describe Phlex::Testing::Rails::ViewHelper do
 	include Phlex::Testing::Rails::ViewHelper


### PR DESCRIPTION
This PR can help resolve [issue#17](https://github.com/joeldrapper/phlex-rails/issues/17). It adds in the folder for the `Rails` namespacing and renames the file to `view_helper` so that Zeitwerk won't complain about the `Phlex::Testing::Rails::ViewHelper` module name. Also added a branch to the gemfile so that `bundle install` could execute successfully. 