### PR TITLE
Fix Zeitwerk loader

### DIFF
--- a/config/sus.rb
+++ b/config/sus.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "phlex/rails"
+
+Zeitwerk::Loader.eager_load_all

--- a/lib/phlex/rails.rb
+++ b/lib/phlex/rails.rb
@@ -4,8 +4,9 @@ require "phlex"
 require "phlex/rails/engine"
 
 module Phlex::Rails
-	Loader = Zeitwerk::Loader.for_gem(warn_on_extra_files: false).tap do |loader|
+	Loader = Zeitwerk::Loader.new.tap do |loader|
 		loader.push_dir("#{__dir__}/rails", namespace: Phlex::Rails)
+		loader.inflector = Zeitwerk::GemInflector.new(__FILE__)
 		loader.setup
 	end
 


### PR DESCRIPTION
The Zeitwerk loader `for_gem` was adding `lib`, but we only want to add `lib/rails`.

Closes #20