### PR TITLE
Warn when overriding `append` and `safe_append` methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   tests:
     strategy:
+      fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
         ruby-version: ['2.7', '3.0', '3.1', 'head']
@@ -19,6 +20,9 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: false
+
+      - name: Update RubyGems
+        run: gem update --system
 
       - name: Install dependencies
         run: bundle install

--- a/lib/phlex/rails.rb
+++ b/lib/phlex/rails.rb
@@ -10,5 +10,16 @@ module Phlex::Rails
 		loader.setup
 	end
 
+	module AppendMethodAddedWarning
+		def method_added(name)
+			if name == :append || name == :safe_append
+				raise Phlex::NameError, "You shouldn't redefine the #{name} method as it's required for safe HTML output."
+			end
+
+			super
+		end
+	end
+
 	Phlex::HTML.prepend(Phlex::Rails::Renderable)
+	Phlex::HTML.extend(Phlex::Rails::AppendMethodAddedWarning)
 end

--- a/test/rails/append_method_added_warning.rb
+++ b/test/rails/append_method_added_warning.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe Phlex::Rails::AppendMethodAddedWarning do
+	it "raises a warning when overriding the append method" do
+		expect {
+			Class.new(Phlex::HTML) do
+				def append
+				end
+			end
+		}.to raise_exception Phlex::NameError
+	end
+
+	it "raises a warning when overriding the safe_append method" do
+		expect {
+			Class.new(Phlex::HTML) do
+				def safe_append
+				end
+			end
+		}.to raise_exception Phlex::NameError
+	end
+end


### PR DESCRIPTION
The `append` and `safe_append` methods are used for compatibility with Rails. Overriding them could result in unsafe HTML output so we should issue a warning if you attempt to override them.