### PR TITLE
Use `unbuffered` reference on the view

### DIFF
--- a/lib/phlex/rails/renderable.rb
+++ b/lib/phlex/rails/renderable.rb
@@ -24,7 +24,7 @@ module Phlex
 
 							if args.length == 1 && Phlex::HTML === args[0]
 								output = yield(
-									Unbuffered.call(args[0])
+									args[0].unbuffered
 								)
 							else
 								output = yield(*args)


### PR DESCRIPTION
Since this PR, we can now use the `unbuffered` reference directly on the view. https://github.com/joeldrapper/phlex/pull/470