### PR TITLE
Declare HTML format

### DIFF
--- a/lib/phlex/rails/html/class_methods.rb
+++ b/lib/phlex/rails/html/class_methods.rb
@@ -7,6 +7,10 @@ module Phlex
 				def render_in(...)
 					new.render_in(...)
 				end
+
+				def format
+					:html
+				end
 			end
 		end
 	end

--- a/lib/phlex/rails/html/overrides.rb
+++ b/lib/phlex/rails/html/overrides.rb
@@ -4,6 +4,10 @@ module Phlex
 	module Rails
 		module HTML
 			module Overrides
+				def format
+					:html
+				end
+
 				def helpers
 					if defined?(ViewComponent::Base) && @_view_context.is_a?(ViewComponent::Base)
 						@_view_context.helpers
@@ -53,6 +57,7 @@ module Phlex
 					end
 				end
 
+				# @api private
 				def safe_append=(value)
 					return unless value
 
@@ -63,6 +68,7 @@ module Phlex
 					end
 				end
 
+				# @api private
 				def append=(value)
 					case value
 					when ActiveSupport::SafeBuffer


### PR DESCRIPTION
1. We need `Phlex::HTML` classes to respond to `format` with `:html` in order to support rendering classes rather than instances when there are no instance arguments to provide.
2. I’d like to remove the `format` method from the instance in Phlex core, so I’m moving that here.