### PR TITLE
Support Rails layout interface

### DIFF
--- a/lib/generators/phlex/component/component_generator.rb
+++ b/lib/generators/phlex/component/component_generator.rb
@@ -5,7 +5,7 @@ module Phlex::Generators
 		source_root File.expand_path("templates", __dir__)
 
 		def create_view
-			@path = File.join("app/components", class_path, "#{file_name}_component.rb")
+			@path = File.join("app/views/components", class_path, "#{file_name}_component.rb")
 			template "component.rb.erb", @path
 		end
 	end

--- a/lib/generators/phlex/controller/templates/controller.rb.erb
+++ b/lib/generators/phlex/controller/templates/controller.rb.erb
@@ -2,6 +2,8 @@
 
 <% module_namespacing do -%>
 class <%= class_name %>Controller < <%= parent_class_name.classify %>
+  layout -> { ApplicationLayout }
+  
 <% actions.each do |action| -%>
   def <%= action %>
     render <%= class_name %>::<%= action.camelize %>View.new

--- a/lib/generators/phlex/install/install_generator.rb
+++ b/lib/generators/phlex/install/install_generator.rb
@@ -13,7 +13,17 @@ module Phlex::Generators
 			inject_into_class(
 				APPLICATION_CONFIGURATION_PATH,
 				"Application",
-				%(    config.autoload_paths << "\#{root}/app/components"\n)
+				%(    config.autoload_paths << "\#{root}/app/views/components"\n)
+			)
+		end
+
+		def autoload_layouts
+			return unless APPLICATION_CONFIGURATION_PATH.exist?
+
+			inject_into_class(
+				APPLICATION_CONFIGURATION_PATH,
+				"Application",
+				%(    config.autoload_paths << "\#{root}/app/views/layouts"\n)
 			)
 		end
 
@@ -37,7 +47,11 @@ module Phlex::Generators
 		end
 
 		def create_application_component
-			template "application_component.rb", Rails.root.join("app/components/application_component.rb")
+			template "application_component.rb", Rails.root.join("app/views/components/application_component.rb")
+		end
+
+		def create_application_layout
+			template "application_layout.rb", Rails.root.join("app/views/layouts/application_layout.rb")
 		end
 
 		def create_application_view

--- a/lib/generators/phlex/install/templates/application_layout.rb
+++ b/lib/generators/phlex/install/templates/application_layout.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class ApplicationLayout < ApplicationView
+	include Phlex::Rails::Layout
+
+	def template(&block)
+		doctype
+
+		html do
+			head do
+				title { "You're awesome" }
+				meta name: "viewport", content: "width=device-width,initial-scale=1"
+				csp_meta_tag
+				csrf_meta_tags
+				stylesheet_link_tag "application", data_turbo_track: "reload"
+				javascript_importmap_tags
+			end
+
+			body do
+				main(&block)
+			end
+		end
+	end
+end

--- a/lib/phlex/rails.rb
+++ b/lib/phlex/rails.rb
@@ -15,6 +15,4 @@ module Phlex::Rails
 
 	Phlex::HTML.extend(Phlex::Rails::HTML::ClassMethods)
 	Phlex::HTML.extend(Phlex::Rails::HTML::AppendMethodAddedWarning)
-
-	Phlex::HTML.include(Phlex::Rails::Helpers::ContentFor)
 end

--- a/lib/phlex/rails.rb
+++ b/lib/phlex/rails.rb
@@ -15,4 +15,6 @@ module Phlex::Rails
 
 	Phlex::HTML.extend(Phlex::Rails::HTML::ClassMethods)
 	Phlex::HTML.extend(Phlex::Rails::HTML::AppendMethodAddedWarning)
+
+	Phlex::HTML.include(Phlex::Rails::Helpers::ContentFor)
 end

--- a/lib/phlex/rails/layout.rb
+++ b/lib/phlex/rails/layout.rb
@@ -29,6 +29,8 @@ module Phlex::Rails
 					when ActiveSupport::SafeBuffer
 						component.unsafe_raw output
 					end
+
+					nil
 				end
 			end
 

--- a/lib/phlex/rails/layout.rb
+++ b/lib/phlex/rails/layout.rb
@@ -12,5 +12,48 @@ module Phlex::Rails
 		include Helpers::JavaScriptIncludeTag
 		include Helpers::JavaScriptImportMapTags
 		include Helpers::JavaScriptImportModuleTag
+
+		module Interface
+			def render(view, _locals, &block)
+				component = new
+
+				component.call(view_context: view) do |yielded|
+					case yielded
+					when Symbol
+						output = view.view_flow.get(yielded)
+					else
+						output = yield
+					end
+
+					case output
+					when ActiveSupport::SafeBuffer
+						component.unsafe_raw output
+					end
+				end
+			end
+
+			def identifier
+				name
+			end
+
+			def virtual_path
+				return @virtual_path if defined? @virtual_path
+
+				@virtual_path = name&.dup.tap do |n|
+					n.gsub!("::", ".")
+					n.gsub!(/([a-z])([A-Z])/, '\1_\2')
+					n.downcase!
+				end
+			end
+		end
+
+		def self.included(klass)
+			unless klass < Phlex::HTML
+				raise Phlex::ArgumentError,
+					"👋 #{name} should only be included into Phlex::HTML classes."
+			end
+
+			klass.extend(Interface)
+		end
 	end
 end

--- a/spec/internal/app/controllers/articles_controller.rb
+++ b/spec/internal/app/controllers/articles_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ArticlesController < ActionController::Base
+	layout -> { ApplicationLayout }
+
+	def index
+		render Articles::IndexView
+	end
+
+	def show; end
+end

--- a/spec/internal/app/views/articles/index_view.rb
+++ b/spec/internal/app/views/articles/index_view.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Articles::IndexView < Phlex::HTML
+	include Phlex::Rails::Helpers::ContentFor
+
+	def template
+		content_for(:title) { "Articles" }
+		h1 { "Articles" }
+	end
+end

--- a/spec/internal/app/views/articles/show.html.erb
+++ b/spec/internal/app/views/articles/show.html.erb
@@ -1,0 +1,3 @@
+<% content_for(:title) { "Article" } %>
+
+<h1>Article</h1>

--- a/spec/internal/app/views/layouts/application_layout.rb
+++ b/spec/internal/app/views/layouts/application_layout.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ApplicationLayout < Phlex::HTML
+	include Phlex::Rails::Layout
+
+	def template(&block)
+		doctype
+
+		html do
+			head do
+				title { yield(:title) }
+			end
+
+			body do
+				main(&block)
+			end
+		end
+	end
+end

--- a/spec/internal/config/routes.rb
+++ b/spec/internal/config/routes.rb
@@ -5,4 +5,7 @@ Rails.application.routes.draw do
 	get "view_component", to: "examples#view_component"
 	get "tabs", to: "examples#tabs"
 	get "card", to: "examples#card"
+
+	get "articles/index", to: "articles#index"
+	get "articles/show", to: "articles#show"
 end

--- a/spec/layout_spec.rb
+++ b/spec/layout_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Layouts", type: :request do
+	it "supports phlex views" do
+		get "/articles/index"
+
+		expect(response.body).to eq %(<!DOCTYPE html><html><head><title>Articles</title></head><body><main><h1>Articles</h1></main></body></html>)
+	end
+
+	it "supports erb views" do
+		get "/articles/show"
+
+		expect(response.body).to eq %(<!DOCTYPE html><html><head><title>Article</title></head><body><main>\n<h1>Article</h1>\n</main></body></html>)
+	end
+end


### PR DESCRIPTION
Add support for using a Phlex object as a proper Rails layout.

Layouts can be defined like this

```ruby
class ApplicationLayout < ApplicationView
  include Phlex::Rails::Layout

  def template
    doctype
    html {
      head { yield(:head) }
      body { yield }
    }
  end
end
```

And used like this

```ruby
class MyController < ApplicationController
  layout -> { ApplicationLayout }

  ...
end
```

There is no way for the view to pass arguments to the layout’s initializer, so it doesn't really make sense to define one. The only way to pass content up is to use `content_for(:foo) { "Hi" }` from the view template and `yield(:foo)` from the layout template.

It may make senes to write an abstraction on this that allows you to define `content_for` blocks at the class level on the view and accept content attributes at the class level on the layout.

That could look like this

```ruby
class MyView < ApplicationView
  content_for(:foo) { "Foo" }
  content_for(:bar) { "Bar" }
end

class ApplicationLayout < ApplicationView
  include Phlex::Rails::Layout

  capture :@foo
  capture :@bar

  def template
    div(&@foo)
    div(&@bar)
  end
end
```

The advantage here would be that any processing of those attributes could be done by a method, e.g.

```ruby
def format_bar
  @bar.upcase
end
```