### PR TITLE
Add support for `safe_concat` API

### DIFF
--- a/lib/phlex/rails/html/append_method_added_warning.rb
+++ b/lib/phlex/rails/html/append_method_added_warning.rb
@@ -5,7 +5,7 @@ module Phlex
 		module HTML
 			module AppendMethodAddedWarning
 				def method_added(name)
-					if name == :append || name == :safe_append
+					if name == :append || name == :safe_append= || name == :safe_concat
 						raise Phlex::NameError, "You shouldn't redefine the #{name} method as it's required for safe HTML output."
 					end
 

--- a/lib/phlex/rails/html/overrides.rb
+++ b/lib/phlex/rails/html/overrides.rb
@@ -69,6 +69,9 @@ module Phlex
 				end
 
 				# @api private
+				alias_method :safe_concat, :safe_append=
+
+				# @api private
 				def append=(value)
 					case value
 					when ActiveSupport::SafeBuffer


### PR DESCRIPTION
Some template languages, like slim, seem to call `safe_concat` instead of `safe_append=`. ActionView::OutputBuffer defines them as aliases, so I've copied that same interface here.