### PR TITLE
Fix turbo stream helper

### DIFF
--- a/lib/phlex/rails/helpers.rb
+++ b/lib/phlex/rails/helpers.rb
@@ -1283,13 +1283,6 @@ module Phlex::Rails::Helpers
 		define_output_helper :turbo_include_tags
 	end
 
-	module TurboStream
-		extend Phlex::Rails::HelperMacros
-
-		# @!method turbo_stream(...)
-		define_builder_yielding_helper :turbo_stream, Phlex::Rails::Buffered
-	end
-
 	module TurboStreamFrom
 		extend Phlex::Rails::HelperMacros
 

--- a/lib/phlex/rails/helpers/turbo_stream.rb
+++ b/lib/phlex/rails/helpers/turbo_stream.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Phlex::Rails::Helpers::TurboStream
+	extend Phlex::Rails::HelperMacros
+
+	def turbo_stream(...)
+		Phlex::Rails::Buffered.new(
+			helpers.turbo_stream(...),
+			view: self
+		)
+	end
+end


### PR DESCRIPTION
The turbo stream helper should return a buffered turbo stream tag builder.