### PR TITLE
Fix routing helpers

### DIFF
--- a/lib/phlex/rails/helpers/routes.rb
+++ b/lib/phlex/rails/helpers/routes.rb
@@ -3,8 +3,10 @@
 # An adapter for Rails routing helpers, such as <code>article_path</code>.
 module Phlex::Rails::Helpers
 	module Routes
+		# This must be included first because it defines `url_options` rather than delegating it to the view context.
+		include Rails.application.routes.url_helpers
+
 		include URLOptions
 		include DefaultURLOptions
-		include Rails.application.routes.url_helpers
 	end
 end


### PR DESCRIPTION
The `url_options` adapter needs to be defined after `Rails.application.routes.url_helpers`