### PR TITLE
Rename helpers

### DIFF
--- a/lib/phlex/rails/buffered_check_box_builder.rb
+++ b/lib/phlex/rails/buffered_check_box_builder.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Phlex::Rails
-	class BufferedCheckboxBuilder < Buffered
+	class BufferedCheckBoxBuilder < Buffered
 		# @!method object(...)
 		# @!method text(...)
 		# @!method value(...)

--- a/lib/phlex/rails/buffered_form_builder.rb
+++ b/lib/phlex/rails/buffered_form_builder.rb
@@ -87,7 +87,7 @@ module Phlex::Rails
 		# @!method collection_check_boxes(...)
 		# 	@yield [builder]
 		# 	@yieldparam builder [Phlex::Rails::BufferedCheckboxBuilder]
-		define_builder_yielding_method :collection_check_boxes, ::Phlex::Rails::BufferedCheckboxBuilder
+		define_builder_yielding_method :collection_check_boxes, ::Phlex::Rails::BufferedCheckBoxBuilder
 
 		# @!method collection_radio_buttons(...)
 		# 	@yield [builder]

--- a/lib/phlex/rails/helpers.rb
+++ b/lib/phlex/rails/helpers.rb
@@ -853,7 +853,7 @@ module Phlex::Rails::Helpers
 		define_value_helper :path_to_javascript
 	end
 
-	module PathToStyleSheet
+	module PathToStylesheet
 		extend Phlex::Rails::HelperMacros
 
 		# @!method path_to_stylesheet(...)
@@ -1108,7 +1108,7 @@ module Phlex::Rails::Helpers
 		define_value_helper :strip_tags
 	end
 
-	module StyleSheetLinkTag
+	module StylesheetLinkTag
 		extend Phlex::Rails::HelperMacros
 
 		# @!method stylesheet_link_tag(...)
@@ -1116,14 +1116,14 @@ module Phlex::Rails::Helpers
 		define_output_helper :stylesheet_link_tag
 	end
 
-	module StyleSheetPath
+	module StylesheetPath
 		extend Phlex::Rails::HelperMacros
 
 		# @!method stylesheet_path(...)
 		define_value_helper :stylesheet_path
 	end
 
-	module StyleSheetURL
+	module StylesheetURL
 		extend Phlex::Rails::HelperMacros
 
 		# @!method stylesheet_url(...)
@@ -1348,7 +1348,7 @@ module Phlex::Rails::Helpers
 		define_value_helper :url_to_javascript
 	end
 
-	module URLToStyleSheet
+	module URLToStylesheet
 		extend Phlex::Rails::HelperMacros
 
 		# @!method url_to_stylesheet(...)

--- a/lib/phlex/rails/helpers.rb
+++ b/lib/phlex/rails/helpers.rb
@@ -94,7 +94,7 @@ module Phlex::Rails::Helpers
 		define_output_helper_with_capture_block :button_to
 	end
 
-	module Checkbox
+	module CheckBox
 		extend Phlex::Rails::HelperMacros
 
 		# @!method check_box(...)
@@ -102,7 +102,7 @@ module Phlex::Rails::Helpers
 		define_output_helper :check_box
 	end
 
-	module CheckboxTag
+	module CheckBoxTag
 		extend Phlex::Rails::HelperMacros
 
 		# @!method check_box_tag(...)
@@ -117,13 +117,13 @@ module Phlex::Rails::Helpers
 		define_value_helper :class_names
 	end
 
-	module CollectionCheckboxes
+	module CollectionCheckBoxes
 		extend Phlex::Rails::HelperMacros
 
 		# @!method collection_check_boxes(...)
 		# 	@yield [builder]
-		# 	@yieldparam builder [Phlex::Rails::BufferedCheckboxBuilder]
-		define_builder_yielding_helper :collection_check_boxes, Phlex::Rails::BufferedCheckboxBuilder
+		# 	@yieldparam builder [Phlex::Rails::BufferedCheckBoxBuilder]
+		define_builder_yielding_helper :collection_check_boxes, Phlex::Rails::BufferedCheckBoxBuilder
 	end
 
 	module CollectionRadioButtons

--- a/lib/phlex/rails/layout.rb
+++ b/lib/phlex/rails/layout.rb
@@ -6,7 +6,7 @@ module Phlex::Rails
 		include Helpers::CSRFMetaTags
 		include Helpers::FaviconLinkTag
 		include Helpers::PreloadLinkTag
-		include Helpers::StyleSheetLinkTag
+		include Helpers::StylesheetLinkTag
 		include Helpers::ActionCableMetaTag
 		include Helpers::AutoDiscoveryLinkTag
 		include Helpers::JavaScriptIncludeTag


### PR DESCRIPTION
Rename helper modules for consistency with Rails naming. “Checkbox” is technically one word, and “Style Sheet” is technically two words, but Rails gets this wrong, and the adapters should match.

- Rename `Checkbox` → `CheckBox`
- Rename `StyleSheet` → `Stylesheet`