### PR TITLE
Add `Phlex::Rails::Helpers::URLFor`

### DIFF
--- a/lib/phlex/rails/helpers.rb
+++ b/lib/phlex/rails/helpers.rb
@@ -1306,6 +1306,13 @@ module Phlex::Rails::Helpers
 		define_output_helper :url_field_tag
 	end
 
+	module URLFor
+		extend Phlex::Rails::HelperMacros
+
+		# @!method url_for(...)
+		define_value_helper :url_for
+	end
+
 	module URLOptions
 		extend Phlex::Rails::HelperMacros
 


### PR DESCRIPTION
This pull request adds a `Phlex::Rails::Helpers::URLFor` module which defines the `url_for` helper. Seems like that one was missing.